### PR TITLE
ci: add GitHub Actions CI and pub.dev auto-publish pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   analyze-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Installs the Flutter SDK (which bundles Dart) onto the runner.
       # This is the GitHub Actions equivalent of a GitLab "image:" with the tools baked in.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+# Validate the package on every pull request and on pushes to main.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel an in-progress run when a newer commit is pushed to the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Installs the Flutter SDK (which bundles Dart) onto the runner.
+      # This is the GitHub Actions equivalent of a GitLab "image:" with the tools baked in.
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify formatting
+        # If this fails, run `dart format .` locally once and commit the result.
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       # with pub.dev — no API tokens or secrets are stored in GitHub.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to pub.dev
+
+# Publishing is triggered by pushing a version tag, e.g. `v1.4.0`.
+# The tag must match the `version:` in pubspec.yaml — pub.dev enforces this via the
+# `v{{version}}` tag pattern configured in the package's Automated Publishing settings.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for OIDC. The pub client uses this short-lived token to authenticate
+      # with pub.dev — no API tokens or secrets are stored in GitHub.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Fail fast on packaging/validation problems before any upload happens.
+      - name: Validate package
+        run: dart pub publish --dry-run
+
+      # Non-interactive publish. OIDC credentials are detected automatically from the
+      # `id-token: write` permission above.
+      - name: Publish
+        run: dart pub publish --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      # Required for OIDC. The pub client uses this short-lived token to authenticate
-      # with pub.dev — no API tokens or secrets are stored in GitHub.
+      # Required to mint the OIDC token used to authenticate with pub.dev.
+      # No API tokens or secrets are stored in GitHub.
       id-token: write
     steps:
       - uses: actions/checkout@v5
@@ -25,11 +25,25 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      # subosito/flutter-action does NOT configure pub.dev OIDC (only dart-lang/setup-dart
+      # does). Without this, `dart pub publish` finds no credential and falls back to the
+      # interactive localhost OAuth flow, which cannot work on a CI runner. This step
+      # replicates what setup-dart's createPubOIDCToken() does: request a GitHub OIDC token
+      # with audience https://pub.dev, expose it as PUB_TOKEN, and tell pub to read it.
+      - name: Authenticate to pub.dev via OIDC
+        run: |
+          set -euo pipefail
+          PUB_TOKEN="$(curl -sSfL \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://pub.dev" | jq -r '.value')"
+          echo "::add-mask::${PUB_TOKEN}"
+          echo "PUB_TOKEN=${PUB_TOKEN}" >> "${GITHUB_ENV}"
+          dart pub token add https://pub.dev --env-var PUB_TOKEN
+
       # Fail fast on packaging/validation problems before any upload happens.
       - name: Validate package
         run: dart pub publish --dry-run
 
-      # Non-interactive publish. OIDC credentials are detected automatically from the
-      # `id-token: write` permission above.
+      # Non-interactive publish; authenticates with the PUB_TOKEN configured above.
       - name: Publish
         run: dart pub publish --force

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,0 +1,49 @@
+# Developer / Release Guide
+
+This package is published to [pub.dev](https://pub.dev/packages/sovendus_voucher_network_and_checkout_benefits)
+via **GitHub Actions**. There are two workflows:
+
+- **`.github/workflows/ci.yml`** — runs on every pull request and push to `main`:
+  `flutter pub get` → format check → `flutter analyze` → `flutter test`.
+- **`.github/workflows/publish.yml`** — runs when a `v*` git tag is pushed and publishes
+  the package to pub.dev using **OIDC** (no API tokens or secrets are stored in GitHub).
+
+## One-time setup (pub.dev admin, required before the first tagged publish)
+
+A pub.dev **admin/uploader** of this package must enable automated publishing once:
+
+1. Go to the package page on pub.dev → **Admin** tab → **Automated publishing**.
+2. Enable **Publishing from GitHub Actions**.
+3. Repository: `Sovendus-GmbH/Sovendus-Voucher-Network-and-Checkout-Benefits-Documentation-for-Flutter-Apps`
+4. Tag pattern: `v{{version}}`
+
+The tag pattern means a tag `v1.4.0` is only allowed to publish pubspec `version: 1.4.0` —
+if they don't match, pub.dev rejects the publish.
+
+If you are not yet an uploader on the `sovendus.com` publisher, ask an existing admin to add you.
+
+## Releasing a new version
+
+1. Bump `version:` in `pubspec.yaml`.
+2. Add a matching section to `CHANGELOG.md` (pub.dev requires the new version to be documented).
+3. Merge to `main` (CI must be green).
+4. Tag and push:
+   ```bash
+   git tag v1.4.0          # must equal the pubspec version
+   git push origin v1.4.0
+   ```
+5. The **Publish to pub.dev** workflow runs, validates with `dart pub publish --dry-run`,
+   then publishes. Confirm the new version appears on pub.dev.
+
+## Local checks before pushing
+
+```bash
+flutter pub get
+dart format .                 # fix formatting (CI enforces this)
+flutter analyze
+flutter test
+dart pub publish --dry-run    # validate packaging without uploading
+```
+
+> Note: the CI format step (`dart format --set-exit-if-changed`) will fail if the code is not
+> formatted. If it fails on the first run, run `dart format .` once and commit the result.

--- a/lib/src/sovendus_voucher_network_and_checkout_benefits.dart
+++ b/lib/src/sovendus_voucher_network_and_checkout_benefits.dart
@@ -132,7 +132,7 @@ class SovendusOrderData {
 }
 
 class SovendusBanner extends StatefulWidget {
-  SovendusBanner({
+  const SovendusBanner({
     super.key,
     required this.trafficSourceNumber,
     required this.trafficMediumNumber,

--- a/test/sovendus_voucher_network_and_checkout_benefits_test.dart
+++ b/test/sovendus_voucher_network_and_checkout_benefits_test.dart
@@ -1,12 +1,19 @@
-// import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
-// import 'package:sovendus_banner/sovendus_banner.dart';
+import 'package:sovendus_voucher_network_and_checkout_benefits/sovendus_voucher_network_and_checkout_benefits.dart';
 
 void main() {
-  // test('adds one to input values', () {
-  //   final calculator = Calculator();
-  //   expect(calculator.addOne(2), 3);
-  //   expect(calculator.addOne(-7), -6);
-  //   expect(calculator.addOne(0), 1);
-  // });
+  test('SovendusBanner exposes the values it was constructed with', () {
+    const banner = SovendusBanner(
+      trafficSourceNumber: 1234,
+      trafficMediumNumber: 5678,
+      hasConsent: true,
+      customerData: SovendusCustomerData(firstName: 'John', lastName: 'Smith'),
+    );
+
+    expect(banner.trafficSourceNumber, 1234);
+    expect(banner.trafficMediumNumber, 5678);
+    expect(banner.hasConsent, isTrue);
+    expect(banner.customerData?.firstName, 'John');
+  });
 }


### PR DESCRIPTION
Add two workflows and a release runbook:
- ci.yml: pub get, format check, analyze, and test on PRs and pushes to main
- publish.yml: publish to pub.dev on v* tags via OIDC (no stored secrets)
- README-dev.md: document the release process and one-time pub.dev setup